### PR TITLE
Update workflow.yml to include Postgres 17

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        postgres_version: [ "14", "15", "16" ]
+        postgres_version: [ "14", "15", "16", "17" ]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
I am just guessing that this change will make the ci produce an image for Postgres 17 as well. Feel free to correct me if other things need to be done for that as well.

That support is needed, because the MASH-Playbook already deploys Postgres 17 which currently can not be backed up (via the borg(matic) role). I already [made an issue there](https://github.com/mother-of-all-self-hosting/mash-playbook/issues/282). Today, I manually set my Postgres version to 17 and noticed that there is no image available here.