### PR TITLE
feat: Add mysqlclient to allow mysqldump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BORGMATIC_VERSION
 
 
 RUN apk add --no-cache libacl || apk add --no-cache acl-libs || echo "Neither libacl, nor acl-libs found!" && \
-		apk add --no-cache lz4-dev zstd-dev xxhash-dev python3 py3-packaging py3-setuptools openssh postgresql${POSTGRES_VERSION}-client socat && \
+		apk add --no-cache lz4-dev zstd-dev xxhash-dev python3 py3-packaging py3-setuptools openssh postgresql${POSTGRES_VERSION}-client socat mysql-client && \
 		apk --no-cache add --virtual builddeps alpine-sdk linux-headers acl-dev py3-cffi py3-pip openssl-dev python3-dev && \
 		ln -s /bin/uname /usr/local/bin/uname && \
 		ln -s /bin/rm /usr/local/bin/rm && \


### PR DESCRIPTION
Borgmatic is theoretically able to do mysqldumps, however the docker image currently does not provide mysqldump (see
https://github.com/mother-of-all-self-hosting/mash-playbook/issues/387). This PR adds this support